### PR TITLE
Add AI fitness app skeleton with ChatGPT coach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.packages
+.pub-cache/
+.pub/
+build/
+ios/Flutter/Flutter.podspec
+# IntelliJ related
+*.iml
+.idea/
+.packages
+# VS Code related
+.vscode/
+# Mac related
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# codex1
-Test CodeX
+# AI Fitness Coach
+
+Cross-platform Flutter app serving as a personal fitness companion with ChatGPT integration.
+
+## Features
+- Dashboard, workout tracking, chat-based AI coach and settings screens
+- ChatGPT integration via OpenAI API
+- Simple models and widgets for workouts and progress
+
+## Getting Started
+1. Install [Flutter](https://flutter.dev) and ensure `flutter` is on your PATH.
+2. Run `flutter pub get` to fetch dependencies.
+3. Use `flutter run` to launch on your desired platform.
+4. Set your OpenAI API key in `lib/screens/chat_screen.dart` or provide it securely via backend.
+
+## Testing
+Run `flutter analyze` for static analysis and `flutter test` to execute tests.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'screens/dashboard_screen.dart';
+import 'screens/workout_screen.dart';
+import 'screens/chat_screen.dart';
+import 'screens/settings_screen.dart';
+
+void main() {
+  runApp(const ProviderScope(child: AIxFitnessApp()));
+}
+
+class AIxFitnessApp extends StatelessWidget {
+  const AIxFitnessApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'AI Fitness Coach',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const MainNavigation(),
+    );
+  }
+}
+
+class MainNavigation extends StatefulWidget {
+  const MainNavigation({super.key});
+  @override
+  State<MainNavigation> createState() => _MainNavigationState();
+}
+
+class _MainNavigationState extends State<MainNavigation> {
+  int _currentIndex = 0;
+  final _pages = const [
+    DashboardScreen(),
+    WorkoutScreen(),
+    ChatScreen(),
+    SettingsScreen(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _pages[_currentIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (i) => setState(() => _currentIndex = i),
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Dashboard'),
+          BottomNavigationBarItem(icon: Icon(Icons.fitness_center), label: 'Training'),
+          BottomNavigationBarItem(icon: Icon(Icons.chat_bubble), label: 'Coach'),
+          BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Einstellungen'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,0 +1,6 @@
+class UserProfile {
+  final String name;
+  final double weight;
+
+  UserProfile({required this.name, required this.weight});
+}

--- a/lib/models/workout.dart
+++ b/lib/models/workout.dart
@@ -1,0 +1,13 @@
+class Workout {
+  final String name;
+  final int sets;
+  final int reps;
+  final double weight;
+
+  Workout({
+    required this.name,
+    required this.sets,
+    required this.reps,
+    required this.weight,
+  });
+}

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import '../services/openai_service.dart';
+
+class ChatScreen extends StatefulWidget {
+  const ChatScreen({super.key});
+  @override
+  State<ChatScreen> createState() => _ChatScreenState();
+}
+
+class _ChatScreenState extends State<ChatScreen> {
+  final _controller = TextEditingController();
+  final _chatHistory = <String>[];
+  late final OpenAIService _openai;
+
+  @override
+  void initState() {
+    super.initState();
+    _openai = OpenAIService('DEIN_OPENAI_API_KEY');
+  }
+
+  Future<void> _sendMessage() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+    setState(() => _chatHistory.add('Du: $text'));
+    _controller.clear();
+
+    try {
+      final reply = await _openai.sendMessage(text);
+      setState(() => _chatHistory.add('Coach: $reply'));
+    } catch (e) {
+      setState(() => _chatHistory.add('Coach: Fehler – $e'));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('KI-Coach')),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              itemCount: _chatHistory.length,
+              itemBuilder: (context, i) => Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(_chatHistory[i]),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration: const InputDecoration(
+                      labelText: 'Frage an den Coach...',
+                    ),
+                  ),
+                ),
+                IconButton(
+                  onPressed: _sendMessage,
+                  icon: const Icon(Icons.send),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class DashboardScreen extends StatelessWidget {
+  const DashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('Willkommen beim AI Fitness Coach!')),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('Einstellungen kommen später.')),
+    );
+  }
+}

--- a/lib/screens/workout_screen.dart
+++ b/lib/screens/workout_screen.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class WorkoutScreen extends StatelessWidget {
+  const WorkoutScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('Deine Workouts erscheinen hier.')),
+    );
+  }
+}

--- a/lib/services/openai_service.dart
+++ b/lib/services/openai_service.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class OpenAIService {
+  final String apiKey;
+
+  OpenAIService(this.apiKey);
+
+  Future<String> sendMessage(String message) async {
+    final url = Uri.parse('https://api.openai.com/v1/chat/completions');
+    final response = await http.post(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $apiKey',
+      },
+      body: jsonEncode({
+        'model': 'gpt-4o',
+        'messages': [
+          {
+            'role': 'system',
+            'content': 'Du bist ein motivierender Fitness-Coach.'
+          },
+          {'role': 'user', 'content': message},
+        ],
+      }),
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      final reply = data['choices'][0]['message']['content'];
+      return reply.trim();
+    } else {
+      throw Exception('Fehler beim Aufruf von OpenAI: ${response.body}');
+    }
+  }
+}

--- a/lib/services/workout_service.dart
+++ b/lib/services/workout_service.dart
@@ -1,0 +1,11 @@
+import '../models/workout.dart';
+
+class WorkoutService {
+  final workouts = <Workout>[];
+
+  void addWorkout(Workout workout) {
+    workouts.add(workout);
+  }
+
+  List<Workout> getWorkouts() => List.unmodifiable(workouts);
+}

--- a/lib/widgets/progress_chart.dart
+++ b/lib/widgets/progress_chart.dart
@@ -1,0 +1,12 @@
+import 'package:charts_flutter/flutter.dart' as charts;
+import 'package:flutter/material.dart';
+
+class ProgressChart extends StatelessWidget {
+  final List<charts.Series<dynamic, num>> seriesList;
+  const ProgressChart({super.key, required this.seriesList});
+
+  @override
+  Widget build(BuildContext context) {
+    return charts.LineChart(seriesList, animate: true);
+  }
+}

--- a/lib/widgets/workout_card.dart
+++ b/lib/widgets/workout_card.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import '../models/workout.dart';
+
+class WorkoutCard extends StatelessWidget {
+  final Workout workout;
+  const WorkoutCard({super.key, required this.workout});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        title: Text(workout.name),
+        subtitle: Text('${workout.sets} Sätze x ${workout.reps} Wiederholungen'),
+        trailing: Text('${workout.weight} kg'),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,23 @@
+name: ai_fitness_coach
+description: KI-Fitness-App mit ChatGPT
+publish_to: 'none'
+version: 1.0.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^1.2.0
+  shared_preferences: ^2.2.1
+  path_provider: ^2.1.1
+  charts_flutter: ^0.12.0
+  flutter_riverpod: ^2.4.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- scaffold Flutter-based fitness app with dashboard, workout, chat and settings screens
- integrate OpenAI chat completion API for AI coach
- add basic models, services, and widgets

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b446aba8832baa017f686de2a8af